### PR TITLE
Allow to decide entity_path of Mesh3D

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use rerun::{self, Rgba32, EXTERNAL_DATA_LOADER_INCOMPATIBLE_EXIT_CODE};
+use rerun::{self, EntityPath, Rgba32, EXTERNAL_DATA_LOADER_INCOMPATIBLE_EXIT_CODE};
 
 /// This is an executable data-loader plugin for the Rerun Viewer.
 /// Any executable on your `$PATH` with a name that starts with [`rerun-loader-`] will be
@@ -70,10 +70,15 @@ fn load_mesh(rec: &rerun::RecordingStream, args: &Args) -> anyhow::Result<()> {
 
         // If specified, entity_path_prefix will be the entity_path of the mesh.
         // In other cases, it will be its file path.
-        let entity_path = args.entity_path_prefix.as_deref().map_or_else(
-            || rerun::EntityPath::from_file_path(&args.filepath),
-            rerun::EntityPath::from,
-        );
+        let entity_path = args
+            .entity_path_prefix
+            .as_deref()
+            .map_or_else(
+                || rerun::EntityPath::from_file_path(&args.filepath),
+                rerun::EntityPath::from,
+            )
+            .join(&EntityPath::from("/"))
+            .join(&EntityPath::from(mesh.name.as_str()));
 
         rec.log(entity_path, &mesh3d)?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,8 @@ fn load_mesh(rec: &rerun::RecordingStream, args: &Args) -> anyhow::Result<()> {
             ));
         }
 
+        // If specified, entity_path_prefix will be the entity_path of the mesh.
+        // In other cases, it will be its file path.
         let entity_path = args.entity_path_prefix.as_deref().map_or_else(
             || rerun::EntityPath::from_file_path(&args.filepath),
             rerun::EntityPath::from,


### PR DESCRIPTION
Allow to decide `entity_path` of all `Mesh3D`. If specified, `entity-path-prefix` will be the `entity_path`. It allows us to give a specific name to the loaded file in Rerun.